### PR TITLE
Fix link text for API versions 1.34 and 1.35

### DIFF
--- a/_data/toc.yaml
+++ b/_data/toc.yaml
@@ -1311,9 +1311,9 @@ reference:
       - path: /engine/api/version-history/
         title: Version history overview
       - path: /engine/api/v1.35/
-        title: v1.33 reference
+        title: v1.35 reference
       - path: /engine/api/v1.34/
-        title: v1.33 reference
+        title: v1.34 reference
       - path: /engine/api/v1.33/
         title: v1.33 reference
       - path: /engine/api/v1.32/


### PR DESCRIPTION
### Proposed changes

Noticed that the links to the Docker Engine API docs under "API reference by version" had three links to v1.33 (versions 1.34 and 1.35 had 1.33 in their link text). I've updated the sidebar yaml to agree with the URLs of those links.